### PR TITLE
Modified the system_stats() function in fauxapi_pfsense_interface.inc…

### DIFF
--- a/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_pfsense_interface.inc
+++ b/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_pfsense_interface.inc
@@ -409,8 +409,7 @@ class fauxApiPfsenseInterface {
         $stats['interfacestatus']       = strip_tags(\get_interfacestatus());
         $stats['cpufreq']               = strip_tags(\get_cpufreq());
         $stats['load_average']          = explode(',',str_replace(' ','',strip_tags(\get_load_average())));
-        $stats['mbuf']                  = strip_tags(\get_mbuf());
-        $stats['mbufpercent']           = strip_tags(\get_mbuf(true));
+        strip_tags(\get_mbuf($stats['mbuf'],$stats['mbufpercent']));
         $stats['statepercent']          = strip_tags(\get_pfstate(true));
         
         return $stats;


### PR DESCRIPTION
… to reference the correct way to get mbuf information for pfsense 2.4.x. If this is not patched, the function returns an error when calling the 'system_stats' action