### PR TITLE
Use date -u instead of --utc

### DIFF
--- a/extras/client-libs/bash/fauxapi_lib.sh
+++ b/extras/client-libs/bash/fauxapi_lib.sh
@@ -28,7 +28,7 @@ fauxapi_auth() {
     # NB:-
     #  auth = apikey:timestamp:nonce:HASH(apisecret:timestamp:nonce)
 
-    fauxapi_hash=`echo -n ${fauxapi_apisecret}${fauxapi_timestamp}${fauxapi_nonce} | sha256sum | cut -d' ' -f1`
+    fauxapi_hash=`echo -n ${fauxapi_apisecret}${fauxapi_timestamp}${fauxapi_nonce} | (sha256sum 2>/dev/null  || shasum -a 256 2>/dev/null) | cut -d' ' -f1`
     fauxapi_auth=${fauxapi_apikey}:${fauxapi_timestamp}:${fauxapi_nonce}:${fauxapi_hash}
 
     echo ${fauxapi_auth}

--- a/extras/client-libs/bash/fauxapi_lib.sh
+++ b/extras/client-libs/bash/fauxapi_lib.sh
@@ -22,7 +22,7 @@ fauxapi_auth() {
     fauxapi_apikey=${1}
     fauxapi_apisecret=${2}
 
-    fauxapi_timestamp=`date --utc +%Y%m%dZ%H%M%S`
+    fauxapi_timestamp=`date -u +%Y%m%dZ%H%M%S`
     fauxapi_nonce=`head -c 40 /dev/urandom | md5sum | head -c 8`
 
     # NB:-


### PR DESCRIPTION
Attempting to run this script on Mac OS will fail because the date utility on Mac OS does not support the `--utc` switch. Mac OS, [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=date&apropos=0&sektion=0&manpath=FreeBSD+12-current&arch=default&format=html), and [Linux](https://www.gnu.org/software/coreutils/manual/html_node/date-invocation.html#date-invocation) all support -u for the same functionality instead.

In addition to this change, getting the script to work on MacOS still requires you to install GNU Coreutils and link `sha256sum` into your path:

```bash
# Using homebrew
brew install coreutils
sudo ln -s /usr/local/bin/gsha256sum /usr/local/bin/sha256sum
```

This requirement could probably be removed with some bash ( e.g. `(sha256sum 2>/dev/null  || shasum -a 256)` ) but I don't have the expertise to validate it in a relatively short amount of time.