### PR TITLE
Depricated php split function replaced with explode 

### DIFF
--- a/extras/client-libs/bash/fauxapi_lib.sh
+++ b/extras/client-libs/bash/fauxapi_lib.sh
@@ -23,7 +23,7 @@ fauxapi_auth() {
     fauxapi_apisecret=${2}
 
     fauxapi_timestamp=`date -u +%Y%m%dZ%H%M%S`
-    fauxapi_nonce=`head -c 40 /dev/urandom | md5sum | head -c 8`
+    fauxapi_nonce=`head -c 40 /dev/urandom | (md5sum 2>/dev/null  || md5 2>/dev/null) | head -c 8`
 
     # NB:-
     #  auth = apikey:timestamp:nonce:HASH(apisecret:timestamp:nonce)

--- a/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_auth.inc
+++ b/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_auth.inc
@@ -45,7 +45,7 @@ class fauxApiAuth {
         }
 
         // make sure the AUTH is well formed and has expected input
-        $elements = split(':', fauxApiUtils::sanitize($_SERVER['HTTP_FAUXAPI_AUTH'], array(':')));
+        $elements = explode(':', fauxApiUtils::sanitize($_SERVER['HTTP_FAUXAPI_AUTH'], array(':')));
         if (4 !== count($elements)) {
             fauxApiLogger::error('unexpected number of FAUXAPI_AUTH elements supplied', array(
                 $elements


### PR DESCRIPTION
Tested on PfSense version 2.4.4-RELEASE (amd64) 
Recieved error before fix:

Fatal error: Uncaught Error: Call to undefined function fauxapi\v1\split() in /etc/inc/fauxapi/fauxapi_auth.inc:48

Also a minor compatibility change for macOs users for the test to work out of the box :)
