### PR TITLE
New API: system_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ tasks feasible.
  - [send_event](#user-content-send_event) - Performs a pfSense "send_event" command to cause various pfSense system actions.
  - [system_reboot](#user-content-system_reboot) - Reboots the pfSense system.
  - [system_stats](#user-content-system_stats) - Returns various useful system stats.
+ - [system_info](#user-content-system_info) - Returns various useful system info.
 
 
 ## Approach
@@ -866,6 +867,66 @@ curl \
       "mbufpercent": "2"
     }
   }
+}
+```
+---
+### system_info
+ - Returns various useful system info.
+ - HTTP: **GET**
+ - Params: none
+
+*Example Request*
+```bash
+curl \
+    -X GET \
+    --silent \
+    --insecure \
+    --header "fauxapi-auth: <auth-value>" \
+    "https://<host-address>/fauxapi/v1/?action=system_info"
+```
+
+*Example Response*
+```javascript
+{
+    "callid": "5e1d8ceb8ff47",
+    "action": "system_info",
+    "message": "ok",
+    "data": {
+        "info": {
+            "sys": {
+                "platform": {
+                    "name": "VMware",
+                    "descr": "VMware Virtual Machine"
+                },
+                "serial_no": "",
+                "device_id": "719e8c91c2c43b820400"
+            },
+            "pfsense_version": {
+                "product_version_string": "2.4.5-DEVELOPMENT",
+                "product_version": "2.4.5-DEVELOPMENT",
+                "product_version_patch": "0"
+            },
+            "pfsense_remote_version": {
+                "version": "2.4.5.a.20200112.1821",
+                "installed_version": "2.4.5.a.20191218.2354",
+                "pkg_version_compare": "<"
+            },
+            "os_verison": "FreeBSD 11.3-STABLE",
+            "cpu_type": {
+                "cpu_model": "Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz",
+                "cpu_count": "4",
+                "logic_cpu_count": "4 package(s)",
+                "cpu_freq": ""
+            },
+            "kernel_pti_status": "enabled",
+            "mds_mitigation": "inactive",
+            "bios": {
+                "vendor": "Phoenix Technologies LTD",
+                "version": "6.00",
+                "date": "07/29/2019"
+            }
+        }
+    }
 }
 ```
 ---

--- a/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_actions.inc
+++ b/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_actions.inc
@@ -348,6 +348,29 @@ class fauxApiActions {
         );
         return TRUE;
     }
+
+    /**
+     * system_stats()
+     * 
+     * @return boolean
+     */
+    public function system_info() {
+        fauxApiLogger::debug(__METHOD__);
+        
+        $info = $this->PfsenseInterface->system_info();
+        
+        if (empty($info)) {
+            $this->response->http_code = 500;
+            $this->response->message = 'unable to get system info';
+            return FALSE;
+        }
+        $this->response->http_code = 200;
+        $this->response->message = 'ok';
+        $this->response->data = array(
+            'info' => $info
+        );
+        return TRUE;
+    }
     
     /**
      * interface_stats()

--- a/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_pfsense_interface.inc
+++ b/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_pfsense_interface.inc
@@ -27,6 +27,9 @@ include_once '/etc/inc/xmlparse.inc';
 include_once '/etc/inc/notices.inc';
 include_once '/etc/inc/config.lib.inc';
 include_once '/etc/inc/system.inc';
+include_once '/etc/inc/pkg-utils.inc';
+
+include_once '/usr/local/www/includes/functions.inc.php';
 
 class fauxApiPfsenseInterface {
 
@@ -488,6 +491,49 @@ class fauxApiPfsenseInterface {
         
         \send_event($command);
         return TRUE;
+    }
+
+    /**
+     * system_info
+     * 
+     * @return array
+     */
+    public function system_info() {
+        global $g;
+        fauxApiLogger::debug(__METHOD__);
+        $info['sys'] = array (
+            'platform'=>system_identify_specific_platform(),
+            'serial_no' => system_get_serial(),
+            'device_id' => system_get_uniqueid(),
+        );
+        $info['pfsense_version'] = array(
+                'product_version_string'=> $g['product_version_string'],
+                'product_version'=>$g['product_version'],
+                'product_version_patch'=>$g['product_version_patch'],
+            );
+        $info['pfsense_remote_version'] = NULL;
+        $remote_system_version = get_system_pkg_version(false, true);
+        if (is_array($remote_system_version) ) {
+            $info['pfsense_remote_version']= $remote_system_version;
+        }
+        $info['os_verison'] = php_uname("s") . " " . php_uname("r");
+        $info['cpu_type'] = array (
+            'cpu_model' => get_single_sysctl("hw.model"),
+            'cpu_count' => get_cpu_count(),
+            'logic_cpu_count' => get_cpu_count(true),
+            'cpu_freq' => get_cpufreq(),
+            );
+        $info['kernel_pti_status'] = get_single_sysctl('vm.pmap.pti')==0 ?'disabled':'enabled';
+        $info['mds_mitigation'] = get_single_sysctl('hw.mds_disable_state');
+        exec('/bin/kenv -q smbios.bios.vendor 2>/dev/null', $biosvendor);
+        exec('/bin/kenv -q smbios.bios.version 2>/dev/null', $biosversion);
+        exec('/bin/kenv -q smbios.bios.reldate 2>/dev/null', $biosdate);
+        $info['bios'] = array (
+            'vendor' => $biosvendor[0],
+            'version' => $biosversion[0],
+            'date' => $biosdate[0],
+        );
+        return $info;
     }
     
     /**


### PR DESCRIPTION
Closes #47


New API: system_info
 - Returns various useful system info.
 - HTTP: **GET**
 - Params: none

*Example Request*
```bash
curl \
    -X GET \
    --silent \
    --insecure \
    --header "fauxapi-auth: <auth-value>" \
    "https://<host-address>/fauxapi/v1/?action=system_info"
```

*Example Response*
```javascript
{
    "callid": "5e1d8ceb8ff47",
    "action": "system_info",
    "message": "ok",
    "data": {
        "info": {
            "sys": {
                "platform": {
                    "name": "VMware",
                    "descr": "VMware Virtual Machine"
                },
                "serial_no": "",
                "device_id": "719e8c91c2c43b820400"
            },
            "pfsense_version": {
                "product_version_string": "2.4.5-DEVELOPMENT",
                "product_version": "2.4.5-DEVELOPMENT",
                "product_version_patch": "0"
            },
            "pfsense_remote_version": {
                "version": "2.4.5.a.20200112.1821",
                "installed_version": "2.4.5.a.20191218.2354",
                "pkg_version_compare": "<"
            },
            "os_verison": "FreeBSD 11.3-STABLE",
            "cpu_type": {
                "cpu_model": "Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz",
                "cpu_count": "4",
                "logic_cpu_count": "4 package(s)",
                "cpu_freq": ""
            },
            "kernel_pti_status": "enabled",
            "mds_mitigation": "inactive",
            "bios": {
                "vendor": "Phoenix Technologies LTD",
                "version": "6.00",
                "date": "07/29/2019"
            }
        }
    }
}

Signed-off-by: lilinzhe <slayercat.subscription@gmail.com>