### PR TITLE
Use sort by name by default

### DIFF
--- a/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_pfsense_interface.inc
+++ b/pfSense-pkg-FauxAPI/files/etc/inc/fauxapi/fauxapi_pfsense_interface.inc
@@ -750,7 +750,7 @@ class fauxApiPfsenseInterface {
         
         include_once '/etc/inc/gwlb.inc';
         
-        $byname = false;
+        $byname = true;
         return \return_gateways_status($byname);
     }
     


### PR DESCRIPTION
Some interfaces IP address may change over time, making it harder to process outputted data. If data is ordered by name, the json can be parsed perfectly in child systems.